### PR TITLE
fixed miss typed example

### DIFF
--- a/contents/kv.md
+++ b/contents/kv.md
@@ -190,7 +190,7 @@ password    passwd
 データの一部を更新してみましょう。
 
 ```console
-$ vault kv patch kv/iam password=passwd
+$ vault kv patch kv/iam password=passwd-2
 $ vault kv get kv/iam
 ====== Metadata ======
 Key              Value


### PR DESCRIPTION
`Secret Engine 1: Key Value` に誤記と思われるものがありました。

